### PR TITLE
DataStore: Settings (language + preset times) + Pending Tracker; Settings autosave; Reactive timeline; Collapsible Debug Data; Time dialog Tab nav

### DIFF
--- a/DEVELOPER_TOOLS.md
+++ b/DEVELOPER_TOOLS.md
@@ -12,13 +12,13 @@ The app stores data in three places:
    - Location: `/data/data/com.medreminder.app/databases/medication_database`
    - Tables: `medications`, `medication_history`
    
-2. **Pending Medications** (SharedPreferences)
-   - Location: `/data/data/com.medreminder.app/shared_prefs/pending_medications.xml`
-   - Stores: Active notification state
+2. **Pending Medications** (DataStore - Preferences)
+   - Location: `/data/data/com.medreminder.app/datastore/user_prefs.preferences_pb`
+   - Stores: Active notification state (JSON string in key `pending_list`)
    
-3. **App Preferences** (SharedPreferences)
-   - Location: `/data/data/com.medreminder.app/shared_prefs/app_prefs.xml`
-   - Stores: User settings (language, etc.)
+3. **App Preferences** (DataStore - Preferences)
+   - Location: `/data/data/com.medreminder.app/datastore/user_prefs.preferences_pb`
+   - Stores: User settings (language, preset times)
 
 ---
 
@@ -60,20 +60,18 @@ The app stores data in three places:
 
 **Best for:** Quick verification, CI/CD, scripts
 
-### View SharedPreferences
+### View DataStore (Preferences)
 
 ```bash
-# Pending medications
-adb shell "run-as com.medreminder.app cat shared_prefs/pending_medications.xml"
-
-# App settings
-adb shell "run-as com.medreminder.app cat shared_prefs/app_prefs.xml"
+# Raw protobuf (binary)
+adb shell "run-as com.medreminder.app cat datastore/user_prefs.preferences_pb" > user_prefs.preferences_pb
 ```
 
-### List Database Files
+### List Database Files and DataStore directory
 
 ```bash
 adb shell "run-as com.medreminder.app ls -lh databases/"
+adb shell "run-as com.medreminder.app ls -lh datastore/"
 ```
 
 ### Use the Helper Script
@@ -84,7 +82,7 @@ adb shell "run-as com.medreminder.app ls -lh databases/"
 
 This script shows:
 - Pending medications (SharedPreferences)
-- App preferences
+- App preferences (DataStore)
 - Database file sizes
 - Instructions to pull database
 
@@ -177,4 +175,3 @@ For production:
 - Remove debug screens/menus
 - Add proper analytics/crash reporting
 - Consider admin-only export features with authentication
-

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,9 @@ dependencies {
     // ViewModel
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
 
+    // DataStore (Preferences)
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
     // Testing
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/java/com/medreminder/app/MainActivity.kt
+++ b/app/src/main/java/com/medreminder/app/MainActivity.kt
@@ -61,6 +61,10 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.first
+import com.medreminder.app.data.SettingsStore
+import com.medreminder.app.data.userPrefs
 import kotlin.system.exitProcess
 
 /**
@@ -317,22 +321,16 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-// Language preference helpers
+// Language preference helpers (DataStore)
 private fun saveLanguagePreference(context: Context, lang: String) {
-    context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
-        .edit()
-        .putString("language", lang)
-        .apply()
+    runBlocking { SettingsStore.setLanguage(context, lang) }
 }
 
 private fun getLanguagePreference(context: Context): String {
-    return context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
-        .getString("language", "en") ?: "en"
+    return runBlocking { SettingsStore.languageFlow(context).first() }
 }
 
-private fun getCurrentLanguage(context: Context): String {
-    return getLanguagePreference(context)
-}
+private fun getCurrentLanguage(context: Context): String = getLanguagePreference(context)
 
 private fun updateContextLocale(context: Context, language: String): Context {
     val locale = Locale(language)
@@ -1133,6 +1131,10 @@ fun TimelineView(
         MedicationDatabase.getDatabase(context).historyDao()
     }
 
+    // Observe pending medications reactively from DataStore
+    val pendingMeds by PendingMedicationTracker.pendingMedicationsFlow(context)
+        .collectAsState(initial = emptyList())
+
     // Calculate start and end of day
     val (startOfDay, endOfDay) = remember {
         val calendar = java.util.Calendar.getInstance()
@@ -1402,8 +1404,11 @@ fun TimelineView(
                                             // 1. It's in the pending notification tracker (meaning a notification was actually sent)
                                             // OR
                                             // 2. It has history (meaning it was taken/skipped, so we know notification was sent)
-                                            val hasPendingNotification = PendingMedicationTracker.getPendingMedications(context)
-                                                .any { it.medicationId == slot.medication.id && it.hour == slot.hour && it.minute == slot.minute }
+                                            val hasPendingNotification = pendingMeds.any {
+                                                it.medicationId == slot.medication.id &&
+                                                it.hour == slot.hour &&
+                                                it.minute == slot.minute
+                                            }
 
                                             val hasHistoryForThisTime = todayHistory.any { history ->
                                                 val historyCal = java.util.Calendar.getInstance()

--- a/app/src/main/java/com/medreminder/app/data/SettingsStore.kt
+++ b/app/src/main/java/com/medreminder/app/data/SettingsStore.kt
@@ -1,0 +1,22 @@
+package com.medreminder.app.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+val Context.userPrefs by preferencesDataStore(name = "user_prefs")
+
+object SettingsStore {
+    private val LANGUAGE = stringPreferencesKey("language")
+
+    fun languageFlow(context: Context): Flow<String> =
+        context.userPrefs.data.map { prefs -> prefs[LANGUAGE] ?: "en" }
+
+    suspend fun setLanguage(context: Context, lang: String) {
+        context.userPrefs.edit { prefs -> prefs[LANGUAGE] = lang }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Move Settings to Jetpack DataStore (Preferences): language + preset times
- Migrate PendingMedicationTracker to DataStore (no migration; fresh start)
- Fix Settings autosave (save only on change; no default overwrite)
- Timeline observes pending meds via Flow; updates reactively
- Debug Data sections are collapsible (Preferences, Medications, History, Pending)
- Time dialog: Tab/Shift+Tab focus improvements; commit values before moving focus

## Scope
- app/build.gradle.kts: add datastore-preferences
- data:
  - SettingsStore: languageFlow + setLanguage
  - PresetTimesManager: DataStore-backed flow + save
- notifications:
  - PendingMedicationTracker: DataStore key , added 
- ui:
  - SettingsScreen: autosave on user changes; read presets via Flow
  - SetReminderTimesScreen: Tab focus handler + focus loop fix in Select Time dialog
  - DebugDataScreen: collapsible sections; shows language and 4 preset times
  - MainActivity: reactive pending meds in Timeline; DataStore language helpers
- docs:
  - DEVELOPER_TOOLS.md: updated to DataStore paths

## Behavior Changes
- No migration by design (old SharedPreferences ignored for settings + pending)
- Quick Select uses Settings presets; language applies immediately
- Timeline reflects pending med changes without reopening

## Testing
- Settings: set Morning=07 → back → reopen → persists; restart app → persists
- Time dialog: enter hour → Tab to minutes (value retained); Shift+Tab back
- Debug Data: collapse/expand; preferences reflect current values
- Timeline: outstanding indicators update as pending changes

## Risks/Notes
- Leaving non-settings SharedPreferences elsewhere untouched
- Consider pruning debug logs in Timeline later

## Checklist
- [x] Builds locally
- [x] Manual QA of Settings, Time dialog, Timeline, Debug Data
- [x] Docs updated
- [ ] Review copy/wording in Settings & Debug Data